### PR TITLE
cache test experiment

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,15 +15,6 @@ CURRENT_SC_COLUMNS = 92
 
 _DataFrameComparer = Callable[[pd.DataFrame, pd.DataFrame], bool]
 
-@pytest.fixture(autouse=True)
-def be_sequential(request: _FixtureFunction) -> Generator[None, None, None]:
-    if request.node.get_closest_marker("sequential"):  # type: ignore
-        lock = Lock()
-        lock.acquire()
-        yield
-        lock.release()
-    else:
-        yield
 
 @pytest.fixture(name='logging_side_effect')
 def _logging_side_effect() -> Callable:

--- a/tests/pybaseball/cache/test_cache.py
+++ b/tests/pybaseball/cache/test_cache.py
@@ -26,6 +26,13 @@ def _load_mock(monkeypatch: MonkeyPatch, mock_data_1: pd.DataFrame) -> MagicMock
     return load_mock
 
 
+@pytest.fixture(name='save_json_mock')
+def _save_json_mock(monkeypatch: MonkeyPatch) -> MagicMock:
+    save_mock = MagicMock()
+    monkeypatch.setattr(cache.file_utils, 'safe_jsonify', save_mock)
+    return save_mock
+
+
 @pytest.fixture(name='save_mock')
 def _save_mock(monkeypatch: MonkeyPatch) -> MagicMock:
     save_mock = MagicMock()
@@ -33,7 +40,6 @@ def _save_mock(monkeypatch: MonkeyPatch) -> MagicMock:
     return save_mock
 
 
-@pytest.mark.sequential
 def test_cache_enable() -> None:
     enable_mock = MagicMock()
     with patch('pybaseball.cache.config.enable', enable_mock):
@@ -41,7 +47,6 @@ def test_cache_enable() -> None:
         enable_mock.assert_called_once_with(True)
 
 
-@pytest.mark.sequential
 def test_cache_disable() -> None:
     enable_mock = MagicMock()
     with patch('pybaseball.cache.config.enable', enable_mock):
@@ -49,7 +54,6 @@ def test_cache_disable() -> None:
         enable_mock.assert_called_once_with(False)
 
 
-@pytest.mark.sequential
 @patch('pybaseball.cache.config.enabled', False)
 def test_call_cache_disabled(load_mock: MagicMock, save_mock: MagicMock) -> None:
     df_func = MagicMock(return_value=pd.DataFrame([1, 2], columns=['a']))
@@ -66,7 +70,6 @@ def test_call_cache_disabled(load_mock: MagicMock, save_mock: MagicMock) -> None
     save_mock.assert_not_called()
 
 
-@pytest.mark.sequential
 @patch('os.path.exists', MagicMock(return_value=True))
 @patch('os.path.getmtime', MagicMock(return_value=datetime.now().timestamp()))
 @patch('pybaseball.cache.config.enabled', True)
@@ -80,7 +83,9 @@ def test_call_cache_disabled(load_mock: MagicMock, save_mock: MagicMock) -> None
         'dataframe': 'cachefile.csv'
     }
 ))
-def test_call_cache_enabled_loads_cache(mock_data_1: pd.DataFrame, load_mock: MagicMock, save_mock: MagicMock) -> None:
+def test_call_cache_enabled_loads_cache(
+        mock_data_1: pd.DataFrame,
+        load_mock: MagicMock, save_mock: MagicMock, save_json_mock: MagicMock) -> None:
     df_func = MagicMock()
     df_func.__name__ = "df_func"
 
@@ -99,7 +104,6 @@ def test_call_cache_enabled_loads_cache(mock_data_1: pd.DataFrame, load_mock: Ma
     pd.testing.assert_frame_equal(result, mock_data_1)
 
 
-@pytest.mark.sequential
 @patch('os.path.exists', MagicMock(return_value=True))
 @patch('os.path.getmtime', MagicMock(return_value=datetime.now()-timedelta(days=7)).timestamp())
 @patch('pybaseball.cache.config.enabled', True)
@@ -107,7 +111,9 @@ def test_call_cache_enabled_loads_cache(mock_data_1: pd.DataFrame, load_mock: Ma
 @patch('pybaseball.cache.file_utils.load_json', MagicMock(
     return_value={'expires': '2020-01-01', 'filename': 'old_file.csv'}
 ))
-def test_call_cache_ignores_expired(mock_data_1: pd.DataFrame, load_mock: MagicMock, save_mock: MagicMock) -> None:
+def test_call_cache_ignores_expired(
+        mock_data_1: pd.DataFrame, load_mock: MagicMock,
+        save_mock: MagicMock, save_json_mock: MagicMock) -> None:
     df_func = MagicMock(return_value=mock_data_1)
     df_func.__name__ = "df_func"
 
@@ -124,11 +130,12 @@ def test_call_cache_ignores_expired(mock_data_1: pd.DataFrame, load_mock: MagicM
     pd.testing.assert_frame_equal(mock_data_1, save_mock.call_args[0][0])
 
 
-@pytest.mark.sequential
 @patch('pybaseball.cache.config.enabled', True)
 @patch('glob.glob', MagicMock(return_value=[]))
 @patch('os.path.exists', MagicMock(return_value=False))
-def test_call_cache_gets_uncached_data(mock_data_1: pd.DataFrame, load_mock: MagicMock, save_mock: MagicMock) -> None:
+def test_call_cache_gets_uncached_data(
+        mock_data_1: pd.DataFrame, load_mock: MagicMock,
+        save_mock: MagicMock, save_json_mock: MagicMock) -> None:
     df_func = MagicMock(return_value=mock_data_1)
     df_func.__name__ = "df_func"  # type: ignore
 
@@ -145,10 +152,10 @@ def test_call_cache_gets_uncached_data(mock_data_1: pd.DataFrame, load_mock: Mag
     pd.testing.assert_frame_equal(mock_data_1, save_mock.call_args[0][0])
 
 
-@pytest.mark.sequential
 @patch('pybaseball.cache.config.enabled', True)
-def test_call_cache_get_func_data_fails_silently(mock_data_1: pd.DataFrame, thrower: Callable, load_mock: MagicMock,
-                                                 save_mock: MagicMock) -> None:
+def test_call_cache_get_func_data_fails_silently(
+        mock_data_1: pd.DataFrame, thrower: Callable,
+        load_mock: MagicMock, save_mock: MagicMock, save_json_mock: MagicMock) -> None:
     assert cache.config.enabled
 
     df_func = MagicMock(return_value=mock_data_1)
@@ -168,10 +175,10 @@ def test_call_cache_get_func_data_fails_silently(mock_data_1: pd.DataFrame, thro
     save_mock.assert_not_called()
 
 
-@pytest.mark.sequential
 @patch('pybaseball.cache.config.enabled', True)
-def test_call_cache_load_fails_silently(mock_data_1: pd.DataFrame, thrower: Callable, load_mock: MagicMock,
-                                        save_mock: MagicMock) -> None:
+def test_call_cache_load_fails_silently(
+        mock_data_1: pd.DataFrame, thrower: Callable,
+        load_mock: MagicMock, save_mock: MagicMock, save_json_mock: MagicMock) -> None:
     assert cache.config.enabled
     df_func = MagicMock(return_value=mock_data_1)
     df_func.__name__ = "df_func"
@@ -190,10 +197,10 @@ def test_call_cache_load_fails_silently(mock_data_1: pd.DataFrame, thrower: Call
     save_mock.assert_called_once()
 
 
-@pytest.mark.sequential
 @patch('pybaseball.cache.config.enabled', True)
-def test_call_cache_save_fails_silently(mock_data_1: pd.DataFrame, thrower: Callable, empty_load_mock: MagicMock,
-                                        save_mock: MagicMock) -> None:
+def test_call_cache_save_fails_silently(
+        mock_data_1: pd.DataFrame, thrower: Callable,
+        empty_load_mock: MagicMock, save_mock: MagicMock) -> None:
     assert cache.config.enabled
 
     df_func = MagicMock(return_value=mock_data_1)
@@ -213,7 +220,6 @@ def test_call_cache_save_fails_silently(mock_data_1: pd.DataFrame, thrower: Call
     save_mock.assert_not_called()
 
 
-@pytest.mark.sequential
 def test_purge(remove: MagicMock) -> None:
     glob_result = ['1.cache_record.json', '2.cache_record.json']
     glob_mock = MagicMock(return_value=glob_result)
@@ -230,7 +236,6 @@ def test_purge(remove: MagicMock) -> None:
     assert remove.call_count == len(glob_result)
 
 
-@pytest.mark.sequential
 def test_flush(remove: MagicMock) -> None:
     glob_result = ['1.cache_record.json', '2.cache_record.json']
     glob_mock = MagicMock(return_value=glob_result)

--- a/tests/pybaseball/cache/test_cache.py
+++ b/tests/pybaseball/cache/test_cache.py
@@ -70,8 +70,6 @@ def test_call_cache_disabled(load_mock: MagicMock, save_mock: MagicMock) -> None
     save_mock.assert_not_called()
 
 
-@patch('os.path.exists', MagicMock(return_value=True))
-@patch('os.path.getmtime', MagicMock(return_value=datetime.now().timestamp()))
 @patch('pybaseball.cache.config.enabled', True)
 @patch('glob.glob', MagicMock(return_value=['1.cache_record.json']))
 @patch('pybaseball.cache.file_utils.load_json', MagicMock(
@@ -104,8 +102,6 @@ def test_call_cache_enabled_loads_cache(
     pd.testing.assert_frame_equal(result, mock_data_1)
 
 
-@patch('os.path.exists', MagicMock(return_value=True))
-@patch('os.path.getmtime', MagicMock(return_value=datetime.now()-timedelta(days=7)).timestamp())
 @patch('pybaseball.cache.config.enabled', True)
 @patch('glob.glob', MagicMock(return_value=['1.cache_record.json']))
 @patch('pybaseball.cache.file_utils.load_json', MagicMock(
@@ -198,6 +194,16 @@ def test_call_cache_load_fails_silently(
 
 
 @patch('pybaseball.cache.config.enabled', True)
+@patch('glob.glob', MagicMock(return_value=['1.cache_record.json']))
+@patch('pybaseball.cache.file_utils.load_json', MagicMock(
+    return_value={
+        'expires': '3000-01-01',
+        'func': 'df_func',
+        'args': [1, 2],
+        'kwargs': {'val1': 'a'},
+        'dataframe': 'cachefile.csv'
+    }
+))
 def test_call_cache_save_fails_silently(
         mock_data_1: pd.DataFrame, thrower: Callable,
         empty_load_mock: MagicMock, save_mock: MagicMock) -> None:


### PR DESCRIPTION
mocks the `save` method of a cache record, in addition to the already mocked `save_df` method. This prevents json files from being written to disk.